### PR TITLE
expect_equal() -> expect_equivalent()

### DIFF
--- a/inst/tinytest/test_random_steps.R
+++ b/inst/tinytest/test_random_steps.R
@@ -86,7 +86,7 @@ s1
 rs <- random_steps(s1, 1, sl_distr = make_unif_distr(sqrt(2), sqrt(2)),
              ta_distr = make_unif_distr(0, 0))
 
-expect_equal(rs[1, 1:6], rs[2, 1:6])
+expect_equivalent(rs[1, 1:6], rs[2, 1:6])
 expect_equal(rs$case_, c(TRUE, FALSE))
 
 


### PR DESCRIPTION
Please consider this fix which should work with both cran version and next version of dplyr. We plan to release dplyr 1.0.0 on May 15. 