### PR TITLE
hr_locoh speedups

### DIFF
--- a/R/hr_locoh.R
+++ b/R/hr_locoh.R
@@ -70,18 +70,20 @@ hr_locoh.track_xy <- function(x, n = 10, type = "k", levels = 0.95, keep.data = 
   mm <- mcps[mcpAreasOrder]
 
 
-  pp <- rep(NA_integer_, length(ff))
-  seen <- c()
-
-  ## this is still slow
-  for (i in 1:length(ff)) {
-    seen <- union(seen, ff[[i]]$id)
-    pp[i] <- length(unique(seen))
-  }
+  ## Compute vector `pp`, which records what proportion of points,
+  ## cumulatively, have been "seen" with introduction of the nth
+  ## smallest polygon.
+  X <- lapply(ff, "[[", "id")
+  all_polys <- seq_along(X)
+  id_poly <- rep(all_polys, lengths(X))
+  id_pt <- unlist(X)
+  ## Vector with indices of polygon in which nth point first "seen"
+  id_poly <- id_poly[!(duplicated(id_pt))]
+  pp <- findInterval(all_polys, id_poly)
+  pp <- pp/nrow(x)
 
   qq <- list()
   qq[[1]] <- mm[[1]]
-  pp <- pp/nrow(x)
 
   wlevel <- sapply(levels, function(l) which.min(abs(pp - l)))
   for (i in seq_along(wlevel)) {


### PR DESCRIPTION
Together, the two commits in this PR speed up a call to `hr_locoh()` with a track object with 20,000 rows about 4.3 fold, cutting its computation time from ~55 to ~13 seconds. For a track object with 30,000 rows, computation of a home range now takes 20 seconds, whereas the same call completely crashed R with the existing code.

Commit 45202b7 doesn't change the results output by `hr_locoh()`, whereas commit d117c52 does slightly. The `MULTIPOLYGON` output by the revised code is slightly larger (on the order of 0.03%) due to what appears to be a slight bit of buffering used by `st_union()`. The boundaries of the outputted `MULTIPOLYGON`, representing a home range about 16 km in length, differ nowhere by more than about 0.1 mm, so the discrepancy is -- at least for any practical purposes I can imagine -- insignificant, but is nonetheless present.
