### PR TITLE
Fix hr_locoh() to reflect fact that hulls contain their "focal" point

### DIFF
--- a/R/hr_locoh.R
+++ b/R/hr_locoh.R
@@ -51,7 +51,7 @@ hr_locoh.track_xy <- function(x, n = 10, type = "k", levels = 0.95, keep.data = 
   }
 
   xysp <- sp::SpatialPointsDataFrame(x[, c("x_", "y_")], data=data.frame(id=1:nrow(x)))
-  zz <- lapply(1:length(aa), function(i) xysp[aa[[i]], ])
+  zz <- lapply(1:length(aa), function(i) xysp[c(i, aa[[i]]), ])
   mcps <- lapply(zz, function(x) rgeos::gBuffer(rgeos::gConvexHull(x), width = rand_buffer))
   mcpAreas <- sapply(mcps, rgeos::gArea)
 


### PR DESCRIPTION
In `hr_locoh()`, `zz` is a list, each of whose elements is a `SpatialPointsDataFrame` holding the points used to construct the hull
around a given point. `zz` is also used (after being reordered to create `ff`) to compute the cumulative proportion of all points
included within the home range by the addition to it of the nth smallest hull. For both purposes, it's important that each element of zz include not only the nearby points identified by the algorithm specified by `type=` and by the user's choice of `n=`, but also the point with respect to which the other points were identified, as it should always be part of the hull.

The simple tweak proposed here adds the focal point to each element of `zz`. 

FWIW, across a large number of cases I've examined, this change makes the isopleths returned by `amt::hr_locoh()` match much more closely (or completely) those produced by `tlocoh::lhs.iso.add()`, whose author (Andy Lyons) was also one of the coauthors on Getz et al. (2007), the paper that introduced LoCoH. The figure below shows one such comparison, for k-LoCoH with n=5 applied to the first 100 points of the `deer` dataset included in the `amt` package. As the figure titles indicate, analyses were carried out using two versions of `amt::hr_locoh()`, as well as LoCoH implementations in the *tlocoh* and *adehabitatHR* package. (If it would be useful, I'd be happy to share the code used to produce this figure.)

![LoCoH-implementation-comparison](https://user-images.githubusercontent.com/3478309/115137197-88fe0300-9fd9-11eb-9a44-4c2200794351.png)
