### PR TITLE
Rename coordinate columns to "x" and "y" in as_ltraj()

### DIFF
--- a/R/coercion.R
+++ b/R/coercion.R
@@ -170,20 +170,22 @@ as_ltraj <- function(x, ...) {
 #' @export
 #' @rdname coercion
 as_ltraj.track_xy <- function(x, id = "animal_1", ...) {
+  xy <- setNames(coords(x), c("x", "y"))
   if (is.null(list(...)[["id"]])) {
-    adehabitatLT::as.ltraj(coords(x), typeII = FALSE, id = "animal_1", ...)
+    adehabitatLT::as.ltraj(xy, typeII = FALSE, id = "animal_1", ...)
   } else {
-    adehabitatLT::as.ltraj(coords(x), typeII = FALSE, ...)
+    adehabitatLT::as.ltraj(xy, typeII = FALSE, ...)
   }
 }
 
 #' @export
 #' @rdname coercion
 as_ltraj.track_xyt <- function(x, ...) {
+  xy <- setNames(coords(x), c("x", "y"))
   if (is.null(list(...)[["id"]])) {
-    adehabitatLT::as.ltraj(coords(x), date = x$t_, typeII = TRUE, id = "animal_1", ...)
+    adehabitatLT::as.ltraj(xy, date = x$t_, typeII = TRUE, id = "animal_1", ...)
   } else {
-    adehabitatLT::as.ltraj(coords(x), date = x$t_, typeII = TRUE, ...)
+    adehabitatLT::as.ltraj(xy, date = x$t_, typeII = TRUE, ...)
   }
 }
 


### PR DESCRIPTION
Currently, `amt::as_ltraj()` produces an `"ltraj"` object whose coordinate
columns have names `"x_"` and `"y_"`. `adehabitatLT::plot.ltraj()`, though,
expects an `"ltraj"` object in which the coordinate columns have names `"x"`
and `"y"` (see code [here](https://github.com/ClementCalenge/adehabitatLT/blob/master/R/plot.ltraj.r#L36-L39)).

As a result, doing the following fails like so:

```r
library(amt)
library(adehabitatLT)
plot(as_ltraj(deer))
## Error in `[.data.frame`(i, , c("x", "y")) : undefined columns selected
```

This PR makes the call to `plot.ltraj()` shown above work, by renaming
coordinate columns to `"x"` and `"y"` in the methods called by
`amt::as_ltraj()`.