### PR TITLE
fix make_track marked as deprecated

### DIFF
--- a/R/track.R
+++ b/R/track.R
@@ -100,8 +100,7 @@ mk_track <- function(tbl, .x, .y, .t, ..., crs = NA_crs_, order_by_ts = TRUE,
 
   if (!is.na(crs)) {
     if (is(crs, "CRS")) {
-      .Deprecated("It looks like you used `CRS()` to create the crs,
-                  please use the ESPG directly.")
+      warning("It looks like you used `CRS()` to create the crs, please use the ESPG directly.")
       crs <- sf::st_crs(crs)
     } else {
       crs <- sf::st_crs(crs)


### PR DESCRIPTION
`make_track` is marked as deprecated because of the `.Deprecated` function without sufficient arguments. 


Here's the chunk:
https://github.com/jmsigner/amt/blob/master/R/track.R#L103-L104=

Running this locally, we see that `.Deprecated` picks up a default "old" function name from the parent calling environment

`old = as.character(sys.call(sys.parent()))[1L]`

``` r
.Deprecated("It looks like you used `CRS()` to create the crs,
                  please use the ESPG directly.")
#> Warning: '.Deprecated' is deprecated.
#> Use 'It looks like you used `CRS()` to create the crs,
#>                   please use the ESPG directly.' instead.
#> See help("Deprecated")
```

So in the case of within `make_track`, without the old argument set, it marks `make_track` as deprecated. 
```r
make_track <- function() {
    .Deprecated("It looks like you used `CRS()` to create the crs,
                  please use the ESPG directly.")
}

make_track()
#> Warning: 'make_track' is deprecated.
#> Use 'It looks like you used `CRS()` to create the crs,
#>                   please use the ESPG directly.' instead.
#> See help("Deprecated")
```


Some alternatives, probably I would think the simple warning is most straightforward:
```r

.Deprecated(
    "It looks like you used `CRS()` to create the crs, please use the ESPG directly.",
    old = 'CRS',
    new = 'EPSG code'
)
#> Warning: 'CRS' is deprecated.
#> Use 'EPSG code' instead.
#> See help("Deprecated") and help("It looks like you used `CRS()` to create the crs, please use the ESPG directly.-deprecated").

warning("It looks like you used `CRS()` to create the crs, please use the ESPG directly.")
#> Warning: It looks like you used `CRS()` to create the crs, please use the ESPG
#> directly.
```

Maybe with some link in the function's docs to the r spatial posts on the deprecation of `CRS`.

Thanks!
