### PR TITLE
Fix hr_locoh() errors ID'd in Issue #66

### DIFF
--- a/R/hr_locoh.R
+++ b/R/hr_locoh.R
@@ -89,7 +89,8 @@ hr_locoh.track_xy <- function(x, n = 10, type = "k", levels = 0.95, keep.data = 
   for (i in seq_along(wlevel)) {
     ## buffer is necessary, to overcome some topology errors if the polygon is quasi a line
     p1 <- lapply(1:wlevel[i], function(i) sp::Polygon(mm[[i]]@polygons[[1]]@Polygons[[1]]@coords))
-    ff <- sp::SpatialPolygons(list(sp::Polygons(p1, ID=1)))
+    p2 <- lapply(seq_along(p1), function(i) sp::Polygons(p1[i], ID = i))
+    ff <- sp::SpatialPolygons(p2)
     ff <- if (length(ff@polygons) == 1) {
       ff
     } else {


### PR DESCRIPTION
This commit fixes the problems with `hr_locoh()` caused by recent changes to the **sf** package (discussed in #66)

With [this commit](https://github.com/r-spatial/sf/commit/8c3533e418c177f81d6bcd9d518c9994e719c3fc), (as part of its move away from any reliance on the **rgeos** package) the **sf** package modified the code it uses to implement `sf:::st_as_sfc.SpatialPolygons()`. One consequence of this change is that `st_as_sfc()` now handles `SpatialPolygons` containing several overlapping polygons differently than it did before. Previously it converted them faithfully to an `sfc` `MULTIPOLYGON`. Now (while executing [these two lines of code](https://github.com/r-spatial/sf/commit/8c3533e418c177f81d6bcd9d518c9994e719c3fc#diff-dd85b13deb8d19e61442aff57ff0fc57608650968c1e5a6468490f1744f245e7R156-R157)) it often splits overlapping polygons up into multiple smaller polygons. (It's the call to `st_make_valid()` in particular that alters the component polygons, following rules I can guess at but haven't fully unpacked.)

In any case, we can sidestep this issue in **amt** by the simple step of giving each of the polygons that make up `ff` (which is passed to `st_as_sf()` [here](https://github.com/jmsigner/amt/commit/d117c526bc158e3d288f6cf3cc0b91aedfda0dfd#diff-5b844d638f6ba740dea9a1f0acb02659c2fcf75748c0614b9f938285fdbc5d95R98) in `amt:::hr_locoh.track_xy()`) its own ID. By making that single change, this commit restores `hr_locoh()`'s functionality in the half  dozen cases in which I've tested it.