### PR TITLE
Add kde option for hr arg

### DIFF
--- a/R/random_points.R
+++ b/R/random_points.R
@@ -5,7 +5,7 @@
 #' @param n `[integer(1)]` \cr The number of random points.
 #' @param type `[character(1)]` \cr Argument passed to `sf::st_sample`. The default is `random`.
 #' @param level `[numeric(1)]` \cr Home-range level of the minimum convex polygon, used for generating the background samples.
-#' @param hr `[character(1)]` \cr The home range estimator to be used. Currently only MCP is implemented.
+#' @param hr `[character(1)]` \cr The home range estimator to be used. Currently only MCP and KDE is implemented.
 #' @param presence `[track]` \cr The presence points, that will be added to the result.
 #' @param ... `[any]`\cr None implemented.
 #' @note For objects of class `track_xyt` the timestamp (`t_`) is lost.

--- a/R/random_points.R
+++ b/R/random_points.R
@@ -5,7 +5,7 @@
 #' @param n `[integer(1)]` \cr The number of random points.
 #' @param type `[character(1)]` \cr Argument passed to `sf::st_sample`. The default is `random`.
 #' @param level `[numeric(1)]` \cr Home-range level of the minimum convex polygon, used for generating the background samples.
-#' @param hr `[character(1)]` \cr The home range estimator to be used. Currently only MCP and KDE is implemented.
+#' @param hr `[character(1)]` \cr The home range estimator to be used. Currently only "mcp" and "kde" are implemented.
 #' @param presence `[track]` \cr The presence points, that will be added to the result.
 #' @param ... `[any]`\cr None implemented.
 #' @note For objects of class `track_xyt` the timestamp (`t_`) is lost.

--- a/man/random_points.Rd
+++ b/man/random_points.Rd
@@ -28,7 +28,7 @@ random_points(x, ...)
 
 \item{level}{\verb{[numeric(1)]} \cr Home-range level of the minimum convex polygon, used for generating the background samples.}
 
-\item{hr}{\verb{[character(1)]} \cr The home range estimator to be used. Currently only MCP is implemented.}
+\item{hr}{\verb{[character(1)]} \cr The home range estimator to be used. Currently only MCP and KDE is implemented.}
 }
 \value{
 A \code{tibble} with the observed and random points and a new column \code{case_} that indicates if a point is observed (\code{case_ = TRUE}) or random (\verb{case_ TRUE}).


### PR DESCRIPTION
The documentation for `random_points` mentions only MCP is implemented, when the hr arg also accepts "kde". 

``` r
library(amt)
#> 
#> Attaching package: 'amt'
#> The following object is masked from 'package:stats':
#> 
#>     filter


data(deer)

rp1 <- random_points(deer, hr = 'mcp')

plot(rp1)
```

![](https://i.imgur.com/GXIDsPc.png)<!-- -->

``` r


rp2 <- random_points(deer, hr = 'kde')

plot(rp2)
```

![](https://i.imgur.com/xcG1W78.png)<!-- -->

<sup>Created on 2024-11-13 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>